### PR TITLE
Fix syntax highlight

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,10 @@ share_hackernews: false
 
 # Build settings
 markdown:     kramdown
+kramdown:
+   syntax_highlighter_opts:
+      disable : true
+highlighter: none
 redcarpet:
   extensions: ['smart', 'tables', 'with_toc_data']
 permalink:    "/:title/"

--- a/_posts/2020-07-30-makefile.md
+++ b/_posts/2020-07-30-makefile.md
@@ -10,7 +10,7 @@ cover_url: "/images/makefile/cover.jpg"
 
 В жизни многих разработчиков найдётся история про первый рабочий день с новым проектом. После клонирования основного репозитория проекта наступает этап, когда приходится вводить множество команд с определёнными флагами и в заданной последовательности. Без описания команд, в большинстве случаев, невозможно понять что происходит, например:
 
-```sh
+```bash
 # Bash
 touch ~/.bash_history
 ufw allow 3035/tcp || echo 'cant configure ufw'
@@ -34,7 +34,7 @@ sudo systemctl daemon-reload && sudo systemctl restart docker
 
 Со временем становится понятно, что нужен инструмент, способный объединить в себе подобные команды, предоставить к ним удобные шорткаты (*более короткие и простые команды*) и обеспечить самодокументацию проекта. Именно таким инструментом стал *Makefile* и утилита `make`. Этот гайд расскажет, как использование этих инструментов позволит свести процесс разворачивания проекта к нескольким коротким и понятным командам:
 
-```sh
+```bash
 # Bash
 make setup
 make start
@@ -137,7 +137,7 @@ start:
 
 Теперь развернуть и запустить проект достаточно двумя командами:
 
-```sh
+```bash
 # Bash
 make setup # выполнит последовательно: env-prepare sqlite-prepare install key db-prepare
 make start
@@ -157,7 +157,7 @@ test: # цель в мейкфайле
 	php artisan test
 ```
 
-```sh
+```bash
 # Bash
 $ ls
 Makefile
@@ -177,7 +177,7 @@ test:
 .PHONY: test
 ```
 
-```sh
+```bash
 # Bash
 $ make test
 ✓ All tests passed!
@@ -213,7 +213,7 @@ say:
 	echo "Hello, $(HELLO)!"
 ```
 
-```sh
+```bash
 # Bash
 $ make say HELLO=World
 echo "Hello, World!"
@@ -234,7 +234,7 @@ say:
 	echo "Hello, $(HELLO)!"
 ```
 
-```sh
+```bash
 # Bash
 $ make say
 echo "Hello, World!"


### PR DESCRIPTION
Looks like currently there are two syntax highlighters active at the same time: Rouge (default in Jekyll or gem) and [hljs enabled here](https://github.com/Hexlet/hexletguides.github.io/blob/83b089e31eb3ba10e7898d15e46dc7038826626c/_includes/head.html#L96). This causes conflicts + hljs fails to find the specified language name trying to autodetect. One of them needs to go. :imp: 

This PR disables Rouge, because as I understand other Hexlet projects use hljs too.

Before:

![](https://i.imgur.com/F8JQYtK.png)

After:

![](https://i.imgur.com/g24DSZc.png)