### PR TITLE
обновление правил индексации

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,10 @@
 User-agent: *
 Disallow: *?
+Disallow: *.html
+
+User-agent: Yandex
+Disallow: *?
+Disallow: *.html
+Disallow: /amp/
 
 Sitemap: https://guides.hexlet.io/sitemap.xml


### PR DESCRIPTION
в AMP страницах попали в индекс страницы .html, но адреса уже исправили 
закрыл  .html для поисковиков 
закрыл амп для яндекса