### PR TITLE
#422 added Yandex verification html file

### DIFF
--- a/next-app/public/yandex_d1b9fafe78d3bf70.html
+++ b/next-app/public/yandex_d1b9fafe78d3bf70.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    </head>
+    <body>Verification: d1b9fafe78d3bf70</body>
+</html>


### PR DESCRIPTION
Задача [422](https://github.com/Hexlet/hexletguides.github.io/issues/422)
Добавил next-app/public/yandex_d1b9fafe78d3bf70.html

Если всё правильно понял, то в hexlet-guides следующий вариант верификации:
[Create an HTML file with a unique name and content we provide and place it in your site's root directory.](https://yandex.com/support/webmaster/service/rights.html#how-to)

В настоящий момент на http://localhost:3000/yandex_d1b9fafe78d3bf70.html отдаётся нужный html. Всё верно?
