### PR TITLE
Fix anchors

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -196,7 +196,8 @@ export const generateSitemap = async (locale) => {
 const getMatches = (content) => {
   const h2Regex = /^## (.*$)/gim;
   const ignoreRegex = /`{3}([\w]*)\n([\S\s]+?)\n`{3}/gim
-  const contentWithoutMarkdown = content.replace(ignoreRegex, '');
+  const contentWithoutMLComments = content.replace(/{\/\*[\s\S]*?\*\/}/gm, '');
+  const contentWithoutMarkdown = contentWithoutMLComments.replace(ignoreRegex, '');
   const matches = contentWithoutMarkdown.match(h2Regex);
   if (matches) {
     return matches;
@@ -214,10 +215,11 @@ const addLinksToContent = (matches, content) => {
     });
 
     const links = text.map((elem) => {
-      const normilizedLink = elem.replace(/[({,})]/g, '')
-      .split(' ')
-      .join('-')
-      .toLowerCase();
+      const normilizedLink = elem
+        .replace(/[^0-9a-z -]/gim, '')
+        .split(' ')
+        .join('-')
+        .toLowerCase();
       return `- [${elem}](#${normilizedLink})`;
     });
 


### PR DESCRIPTION
#609 
Fixed the regular expression for creating links. Also added trimming of multi-line comments in the markup of articles, without which a link to a non-existent block was created (as here: https://guides.hexlet.io/virtualization/#related-guides )